### PR TITLE
fix a small warning: missing alt

### DIFF
--- a/src/Image.js
+++ b/src/Image.js
@@ -30,7 +30,8 @@ export default class CachedImage extends React.Component {
   render() {
     return (
       this.state.didTimeout ?
-      <img
+      <img 
+        alt='click'
         src={this.props.src}
         onClick={this.props.onClick}
         /> :


### PR DESCRIPTION
./src/Image.js
  Line 33:  img elements must have an alt prop, either with meaningful text, or an empty string for decorative images  jsx-a11y/alt-text